### PR TITLE
Fix to lines that were not wrapping in the PDF

### DIFF
--- a/src/pages/basics/results.md
+++ b/src/pages/basics/results.md
@@ -278,7 +278,7 @@ We will address each part in turn.
 
 First let's create handlers for each content type.
 We have three types to consider:
-`application/x-www-form-url-encoded`, `text/plain`, and `text/tsv`.
+`text/plain` , `text/tsv` , and `application/x-www-form-url-encoded`.
 Play has built-in body parsers for the first two.
 The methods in `CsvHelpers` do most of the rest of the work:
 

--- a/src/pages/html/chat.md
+++ b/src/pages/html/chat.md
@@ -118,7 +118,8 @@ A minimal `chatroom` template takes a `Seq[Message]` as a parameter and
 renders a `<ul>` of messages:
 
 ~~~ html
-@(messages: Seq[services.ChatServiceMessages.Message], chatForm: Form[controllers.ChatController.ChatRequest])
+@(messages: Seq[services.ChatServiceMessages.Message],
+  chatForm: Form[controllers.ChatController.ChatRequest])
 
 ...
 


### PR DESCRIPTION
results.md required a reordering of a list to prevent the wrapping issues.
